### PR TITLE
feat: fatal log example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,16 @@ Before diving into this sample, please complete the following tasks:
 
 ## 🥾 Steps
 
-The following guide assumes your project is targeting Windows, but these steps are applicable to other Desktop platforms as well. On Mobile platforms the BugSplat plugin will automatically configure crash reporting and symbol uploads.
+The following guide assumes your project is targeting Windows, but these steps apply to other Desktop platforms as well. On Mobile platforms, the BugSplat plugin will automatically configure crash reporting and symbol uploads.
 
-1. Before you clone this repo make sure you have [git-lfs](https://git-lfs.github.com/) installed.
-2. Clone this repo and the associated submodules. It's important that this repo is cloned with the `--recurse-submodules` flag so that the [bugsplat-unreal](https://github.com/BugSplat-Git/bugsplat-unreal) plugin is also downloaded:
+1. Before you clone this repo, make sure you have [git-lfs](https://git-lfs.github.com/) installed.
+2. Clone this repo and the associated submodules. This repo must be cloned with the `--recurse-submodules` flag so that the [bugsplat-unreal](https://github.com/BugSplat-Git/bugsplat-unreal) plugin is also downloaded:
 
 ```sh
 git clone https://github.com/BugSplat-Git/my-unreal-crasher --recurse-submodules
 ```
 
-3. Double click the `MyUnrealCrasher.uproject` file to open the project in the Unreal Editor. Depending on the Unreal Engine version you have installed you may need to [Generate Visual Studio project files](https://forums.unrealengine.com/t/how-to-rebuild-my-project-for-include-a-plugin/324613) and build the plug-in from source.
+3. Double-click the `MyUnrealCrasher.uproject` file to open the project in the Unreal Editor. Depending on the Unreal Engine version you have installed, you may need to [Generate Visual Studio project files](https://forums.unrealengine.com/t/how-to-rebuild-my-project-for-include-a-plugin/324613) and build the plug-in from source.
 4. Once the project has been opened, click `Edit > Project Settings` and scroll to the `BugSplat` section under `Plugins`.
 5. Fill in the values for `Database`, `Application`, `Version`, `Client ID`, and `Client Secret`
 
@@ -50,7 +50,8 @@ git clone https://github.com/BugSplat-Git/my-unreal-crasher --recurse-submodules
 
 Run your packaged game to generate a crash report. Navigate to the [Crashes](https://app.bugsplat.com/v2/crashes) page and click the link in the ID column to view the details of your crash
 
-If you did everything correctly your result should look something like this
+If you did everything correctly, your result should look something like this:
 
-<img width="1711" alt="image" src="https://user-images.githubusercontent.com/2646053/181916918-159e6c3a-d11a-4751-81e3-d22f90037d09.png">
+<img width="1728" height="998" alt="image" src="https://github.com/user-attachments/assets/0cc11520-84f9-494f-8822-14c970dbde55" />
+
 

--- a/Source/MyUnrealCrasher/MyUnrealCrasherAndroidErrorOutputDevice.cpp
+++ b/Source/MyUnrealCrasher/MyUnrealCrasherAndroidErrorOutputDevice.cpp
@@ -1,0 +1,111 @@
+// Copyright © BugSplat. All rights reserved.
+#include "MyUnrealCrasherAndroidErrorOutputDevice.h"
+
+#include "CoreMinimal.h"
+#include "CoreGlobals.h"
+#include "Misc/OutputDevice.h"
+#include "Misc/OutputDeviceHelper.h"
+#include "Misc/App.h"
+#include "Misc/CoreDelegates.h"
+#include "Misc/FeedbackContext.h"
+#include "HAL/PlatformMisc.h"
+#include "HAL/PlatformCrt.h"
+
+#if PLATFORM_ANDROID
+#include "Android/AndroidPlatform.h" // For LogAndroid
+
+FOutputDeviceError* FMyUnrealCrasherAndroidErrorOutputDevice::GetErrorOutputDevice()
+{
+	static FMyUnrealCrasherAndroidErrorOutputDevice ErrorOutputDevice;
+	return &ErrorOutputDevice;
+}
+
+void FMyUnrealCrasherAndroidErrorOutputDevice::Serialize( const TCHAR* Msg, ELogVerbosity::Type Verbosity, const class FName& Category )
+{
+	FPlatformMisc::LowLevelOutputDebugString(*FOutputDeviceHelper::FormatLogLine(Verbosity, Category, Msg, GPrintLogTimes));
+
+	static int32 CallCount = 0;
+	int32 NewCallCount = FPlatformAtomics::InterlockedIncrement(&CallCount);
+	if(GIsCriticalError == 0 && NewCallCount == 1)
+	{
+		// First appError.
+		GIsCriticalError = 1;
+
+		FCString::Strncpy(GErrorExceptionDescription, Msg, UE_ARRAY_COUNT(GErrorExceptionDescription));
+	}
+	else
+	{
+		UE_LOG(LogAndroid, Error, TEXT("Error reentered: %s"), Msg);
+	}
+
+	if (GIsGuarded)
+	{
+		UE_DEBUG_BREAK();
+	}
+	else
+	{
+		HandleError();
+		RequestExit(true, TEXT("MyUnrealCrasherAndroidErrorOutputDevice::Serialize.!GIsGuarded"));
+	}
+}
+
+void FMyUnrealCrasherAndroidErrorOutputDevice::HandleError()
+{
+	static int32 CallCount = 0;
+	int32 NewCallCount = FPlatformAtomics::InterlockedIncrement(&CallCount);
+
+	if (NewCallCount != 1)
+	{
+		UE_LOG(LogAndroid, Error, TEXT("HandleError re-entered."));
+		return;
+	}
+	
+	GIsGuarded = 0;
+	GIsRunning = 0;
+	GIsCriticalError = 1;
+	GLogConsole = NULL;
+	GErrorHist[UE_ARRAY_COUNT(GErrorHist) - 1] = 0;
+
+	// Dump the error and flush the log.
+#if !NO_LOGGING
+	FDebug::LogFormattedMessageWithCallstack(LogAndroid.GetCategoryName(), __FILE__, __LINE__, TEXT("=== Critical error: ==="), GErrorHist, ELogVerbosity::Error);
+#endif
+	
+	GLog->Panic();
+
+	FCoreDelegates::OnHandleSystemError.Broadcast();
+	FCoreDelegates::OnShutdownAfterError.Broadcast();
+}
+
+
+void FMyUnrealCrasherAndroidErrorOutputDevice::RequestExit( bool Force, const TCHAR* CallSite)
+{
+
+#if PLATFORM_COMPILER_OPTIMIZATION_PG_PROFILING
+	// Write the PGO profiling file on a clean shutdown.
+	extern void PGO_WriteFile();
+	if (!GIsCriticalError)
+	{
+		PGO_WriteFile();
+		// exit now to avoid a possible second PGO write when AndroidMain exits.
+		Force = true;
+	}
+#endif
+
+	UE_LOG(LogAndroid, Log, TEXT("FMyUnrealCrasherAndroidErrorOutputDevice::RequestExit(%i, %s)"), Force,
+		CallSite ? CallSite : TEXT("<NoCallSiteInfo>"));
+	if (GLog)
+	{
+		GLog->Flush();
+	}
+
+	if (Force)
+	{
+		abort(); // Abort to trigger a crash report
+	}
+	else
+	{
+		RequestEngineExit(TEXT("Android RequestExitWithCrashReporting")); // Called regardless in our version to set up the crash context
+	}
+}
+#endif

--- a/Source/MyUnrealCrasher/MyUnrealCrasherAndroidErrorOutputDevice.h
+++ b/Source/MyUnrealCrasher/MyUnrealCrasherAndroidErrorOutputDevice.h
@@ -1,0 +1,21 @@
+//  Copyright © BugSplat. All rights reserved.
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Misc/OutputDeviceError.h"
+
+#if PLATFORM_ANDROID
+class FMyUnrealCrasherAndroidErrorOutputDevice : public FOutputDeviceError
+{
+public:
+	virtual ~FMyUnrealCrasherAndroidErrorOutputDevice() {}
+	
+	virtual void Serialize(const TCHAR* V, ELogVerbosity::Type Verbosity, const FName& Category) override;
+	virtual void HandleError() override;
+	
+	static FOutputDeviceError* GetErrorOutputDevice();
+	
+private:
+	void RequestExit(bool Force, const TCHAR* CallSite);
+};
+#endif

--- a/Source/MyUnrealCrasher/MyUnrealCrasherGameInstance.cpp
+++ b/Source/MyUnrealCrasher/MyUnrealCrasherGameInstance.cpp
@@ -1,0 +1,17 @@
+//  Copyright © BugSplat. All rights reserved.
+#include "MyUnrealCrasherGameInstance.h"
+#include "MyUnrealCrasherAndroidErrorOutputDevice.h"
+
+#if PLATFORM_ANDROID
+#include <android/log.h>
+#endif
+
+void UMyUnrealCrasherGameInstance::Init()
+{
+	Super::Init();
+	UE_LOG(LogTemp, Log, TEXT("MyUnrealCrasherGameInstance::Init - Setting custom error output device"));
+
+#if PLATFORM_ANDROID
+	GError = FMyUnrealCrasherAndroidErrorOutputDevice::GetErrorOutputDevice();
+#endif
+}

--- a/Source/MyUnrealCrasher/MyUnrealCrasherGameInstance.h
+++ b/Source/MyUnrealCrasher/MyUnrealCrasherGameInstance.h
@@ -1,0 +1,15 @@
+//  Copyright © BugSplat. All rights reserved.
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/GameInstance.h"
+#include "MyUnrealCrasherGameInstance.generated.h"
+
+UCLASS()
+class MYUNREALCRASHER_API UMyUnrealCrasherGameInstance : public UGameInstance
+{
+	GENERATED_BODY()
+
+public:
+	virtual void Init() override;
+};


### PR DESCRIPTION
### Description

Adds button that does an Unreal LogFatal. Modifies the Android error handler to abort on LogFatal.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
